### PR TITLE
docs: cut over fullstackbun.dev hosts to estepanov.com

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -223,7 +223,7 @@ This devcontainer configuration is compatible with GitHub Codespaces. To use:
 - [VS Code DevContainers Documentation](https://code.visualstudio.com/docs/devcontainers/containers)
 - [Docker Compose Documentation](https://docs.docker.com/compose/)
 - [Bun Documentation](https://bun.sh/docs)
-- [Project Documentation](https://fullstackbun.dev)
+- [Project Documentation](https://fullstackbun.estepanov.com)
 
 ## Support
 

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+fullstackbun.estepanov.com

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Get Started
 
-PLEASE SEE https://fullstackbun.dev/get-started/
+PLEASE SEE https://fullstackbun.estepanov.com/get-started/
 
 ### VS Code DevContainer (Recommended)
 

--- a/apps/admin/.env.demo
+++ b/apps/admin/.env.demo
@@ -1,4 +1,4 @@
-VITE_API_BASE_URL=https://admin-mock.demo.fullstackbun.dev/mock-api
-VITE_FRONTEND_URL=https://frontend.demo.fullstackbun.dev
+VITE_API_BASE_URL=https://demo-admin-mock-fullstackbun.estepanov.com/mock-api
+VITE_FRONTEND_URL=https://demo-fullstackbun.estepanov.com
 VITE_ADMIN_DEMO=true
 NODE_ENV=production

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -12,13 +12,13 @@ hero:
       link: /get-started
     - theme: alt
       text: Demo Frontend
-      link: https://frontend.demo.fullstackbun.dev
+      link: https://demo-fullstackbun.estepanov.com
     - theme: alt
       text: Demo Mocked Admin
-      link: https://admin-mock.demo.fullstackbun.dev
+      link: https://demo-admin-mock-fullstackbun.estepanov.com
     - theme: alt
       text: Demo Storybook
-      link: https://storybook.demo.fullstackbun.dev
+      link: https://demo-storybook-fullstackbun.estepanov.com
 
 features:
   - title: React 19 + Vite

--- a/apps/docs/public/CNAME
+++ b/apps/docs/public/CNAME
@@ -1,0 +1,1 @@
+fullstackbun.estepanov.com

--- a/apps/docs/reference/storybook.md
+++ b/apps/docs/reference/storybook.md
@@ -52,4 +52,4 @@ The preview command serves the static output from `storybook-static`.
 
 A hosted demo is available at:
 
-- https://storybook.demo.fullstackbun.dev
+- https://demo-storybook-fullstackbun.estepanov.com

--- a/apps/storybook/.storybook/theme.ts
+++ b/apps/storybook/.storybook/theme.ts
@@ -3,7 +3,7 @@ import { create } from "storybook/theming";
 export const storybookTheme = create({
   base: "dark",
   brandTitle: "Fullstack Bun Storybook",
-  brandUrl: "https://fullstackbun.dev",
-  // brandImage: "https://fullstackbun.dev/es-logo-light.svg",
+  brandUrl: "https://fullstackbun.estepanov.com",
+  // brandImage: "https://fullstackbun.estepanov.com/es-logo-light.svg",
   brandTarget: "_self",
 });

--- a/packages/shared/config/notification.ts
+++ b/packages/shared/config/notification.ts
@@ -108,7 +108,7 @@ const getFrontendHostFromEnv = () => {
  */
 export const NOTIFICATION_ACTION_ALLOWED_DOMAINS = [
   getFrontendHostFromEnv(),
-  "fullstackbun.dev",
-  "frontend.demo.fullstackbun.dev",
-  "admin.demo.fullstackbun.dev",
+  "fullstackbun.estepanov.com",
+  "demo-fullstackbun.estepanov.com",
+  "demo-admin-fullstackbun.estepanov.com",
 ].filter((value): value is string => Boolean(value));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This draft updates in-repo docs, examples, configs, and links that still pointed at the old `fullstackbun.dev` docs/demo hosts so they use the new `estepanov.com` hosts.

### Hostname map

| Old host | New host |
| --- | --- |
| `https://fullstackbun.dev` (docs/marketing apex) | `https://fullstackbun.estepanov.com` |
| `https://frontend.demo.fullstackbun.dev` (frontend demo) | `https://demo-fullstackbun.estepanov.com` |
| `https://admin.demo.fullstackbun.dev` (admin demo allowlist) | `https://demo-admin-fullstackbun.estepanov.com` |
| `https://admin-mock.demo.fullstackbun.dev` | `https://demo-admin-mock-fullstackbun.estepanov.com` |
| `https://storybook.demo.fullstackbun.dev` | `https://demo-storybook-fullstackbun.estepanov.com` |

### What changed

- README, VitePress home/storybook docs, Storybook brand URL, and Dev Container docs now link to the new hosts.
- Admin `.env.demo` demo URLs now target the new mock-admin and frontend demo hosts.
- Notification action allowlist in `packages/shared/config/notification.ts` trusts the new docs/frontend/admin demo hosts.
- GitHub Pages custom-domain artifacts set to exactly `fullstackbun.estepanov.com` (no scheme, no path):
  - repo-root `CNAME`
  - `apps/docs/public/CNAME` (copied into the VitePress Pages artifact)

### Pages / DNS status

- Cloudflare already CNAMEs `fullstackbun.estepanov.com` → `estepanov.github.io` (proxied).
- `https://fullstackbun.dev` already 301-redirects to `https://fullstackbun.estepanov.com/`.
- `GET /repos/estepanov/fullstack-bun/pages` already reports `cname: fullstackbun.estepanov.com` and `build_type: workflow`.
- `PUT /repos/estepanov/fullstack-bun/pages` with `cname` + `https_enforced: true` returned **403 Resource not accessible by integration** from this agent token. HTTPS enforcement still needs a repo admin (or a token with Pages write) to flip `https_enforced` to `true`.
- The live site can keep returning GitHub Pages 404 until this CNAME file is on `main` and Pages finishes binding/cert issuance.

### Intentionally unchanged

- GitHub repo URLs (`github.com/estepanov/fullstack-bun`) were left as-is.
- Generic SMTP examples (`noreply@example.com`, `noreply@yourapp.com`, `noreply@yourapp.local`) were not rewritten. There were no `noreply@…demo.fullstackbun.dev` identities in-repo, so no demo-mail address was invented.
- No `https://api-demo.fullstackbun.dev` or hyphenated `frontend-demo` / `admin-demo` live-host strings were present. Nothing to remap for those exact names.
- `admin-demo-welcome` is a localStorage key, not a hostname.
- Docker production credentials, Fly.io placeholders, and runtime secrets were not changed.
- There is no changelog that presents current live URLs.

### Remaining old-host search

Repo-wide search for `fullstackbun.dev`, `frontend-demo`, `api-demo`, `admin-demo`, `storybook.demo`, and `admin-mock.demo` is clean of live hosted demo/docs URLs after this change.

## How to verify

1. Search the repo for `fullstackbun.dev` and confirm no live docs/demo hosts remain.
2. Open README / docs home / Storybook docs and confirm the new `*.estepanov.com` links.
3. Confirm `CNAME` and `apps/docs/public/CNAME` both contain exactly `fullstackbun.estepanov.com`.
4. After Pages deploy from `main`, confirm the docs site is served on `https://fullstackbun.estepanov.com`.
5. In repo Settings → Pages, confirm custom domain `fullstackbun.estepanov.com` and enforce HTTPS.

## Checks

- `bun run lint` passed.
- `bun run test --coverage`: API, shared, and frontend-common suites passed. Frontend/admin suites failed in this environment because `frontend-common` package exports resolve to `dist/` and that package was not built here. That is unrelated to the hostname cutover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2053922c-a35e-4928-809e-2259c67b2bab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2053922c-a35e-4928-809e-2259c67b2bab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

