### PR TITLE
fix: resolve cross-app links from deployed runtime env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ BETTER_AUTH_SECRET="your-secret-key-here"
 # For local development, include both frontend and admin URLs
 CORS_ALLOWLISTED_ORIGINS=http://localhost:5173,http://localhost:5175
 
+# Cross-app public URLs (used by Docker Compose production builds and runtime)
+VITE_API_BASE_URL=http://localhost:3001
+VITE_ADMIN_URL=http://localhost:5175
+VITE_FRONTEND_URL=http://localhost:5173
+
 # Email (SMTP) - for email verification
 SMTP_HOST="smtp.gmail.com"
 SMTP_PORT="587"
@@ -48,7 +53,9 @@ GITHUB_CLIENT_SECRET=""
 
 # Production Configuration
 # CORS_ALLOWLISTED_ORIGINS=https://yourdomain.com,https://admin.yourdomain.com
-# VITE_API_URL=https://api.yourdomain.com
+# VITE_API_BASE_URL=https://api.yourdomain.com
+# VITE_ADMIN_URL=https://admin.yourdomain.com
+# VITE_FRONTEND_URL=https://yourdomain.com
 
 # Note: For production, update the following with secure values:
 # - POSTGRES_PASSWORD (use a strong random password)
@@ -56,4 +63,6 @@ GITHUB_CLIENT_SECRET=""
 # - BETTER_AUTH_SECRET (generate with: openssl rand -base64 32)
 # - SMTP credentials (use secure values)
 # - CORS_ALLOWLISTED_ORIGINS (set to include frontend and admin domains)
-# - VITE_API_URL (set to your production API URL)
+# - VITE_API_BASE_URL (set to your production API URL)
+# - VITE_ADMIN_URL (frontend → admin link)
+# - VITE_FRONTEND_URL (admin → customer app link)

--- a/apps/admin/Dockerfile
+++ b/apps/admin/Dockerfile
@@ -96,6 +96,7 @@ COPY --from=build --chown=bunapp:bunapp /app/node_modules ./node_modules
 COPY --from=build --chown=bunapp:bunapp /app/apps/admin/node_modules ./apps/admin/node_modules
 COPY --from=build --chown=bunapp:bunapp /app/apps/admin/build ./apps/admin/build
 COPY --from=build --chown=bunapp:bunapp /app/apps/admin/server.ts ./apps/admin/server.ts
+COPY --from=build --chown=bunapp:bunapp /app/packages ./packages
 # Drop privileges for runtime
 USER bunapp
 # Expose production port

--- a/apps/admin/fly.toml
+++ b/apps/admin/fly.toml
@@ -14,12 +14,13 @@ primary_region = 'iad'
     VITE_API_BASE_URL = 'https://api.yourdomain.com'
     VITE_FRONTEND_URL = 'https://yourdomain.com'
 
-# Environment variables (public, non-sensitive)
+# Environment variables (public, non-sensitive).
+# Keep VITE_* out of [env] — placeholder values would override per-deploy
+# [build.args] / --build-arg URLs via window.__APP_CONFIG__. Set runtime
+# VITE_FRONTEND_URL only when you intentionally want to override the baked origin.
 [env]
   PORT = '5175'
   NODE_ENV = 'production'
-  VITE_API_BASE_URL = 'https://api.yourdomain.com'
-  VITE_FRONTEND_URL = 'https://yourdomain.com'
 
 # HTTP service configuration
 [[services]]

--- a/apps/admin/fly.toml
+++ b/apps/admin/fly.toml
@@ -18,6 +18,8 @@ primary_region = 'iad'
 [env]
   PORT = '5175'
   NODE_ENV = 'production'
+  VITE_API_BASE_URL = 'https://api.yourdomain.com'
+  VITE_FRONTEND_URL = 'https://yourdomain.com'
 
 # HTTP service configuration
 [[services]]

--- a/apps/admin/locales/de/admin.json
+++ b/apps/admin/locales/de/admin.json
@@ -1,5 +1,7 @@
 {
   "loading": "Wird geladen...",
+  "redirecting": "Weiterleitung zur Anmeldung...",
+  "login_url_missing": "Die URL der Kunden-App ist nicht konfiguriert.",
   "access_denied": "Zugriff verweigert",
   "admin_only": "Dieser Bereich ist nur für Administratoren.",
   "portal": "Admin-Portal",

--- a/apps/admin/locales/en/admin.json
+++ b/apps/admin/locales/en/admin.json
@@ -1,5 +1,7 @@
 {
   "loading": "Loading...",
+  "redirecting": "Redirecting to login...",
+  "login_url_missing": "Customer app URL is not configured.",
   "access_denied": "Access Denied",
   "admin_only": "This area is restricted to administrators only.",
   "portal": "Admin Portal",

--- a/apps/admin/locales/es/admin.json
+++ b/apps/admin/locales/es/admin.json
@@ -1,5 +1,7 @@
 {
   "loading": "Cargando...",
+  "redirecting": "Redirigiendo al inicio de sesión...",
+  "login_url_missing": "La URL de la aplicación de clientes no está configurada.",
   "access_denied": "Acceso denegado",
   "admin_only": "Esta área está restringida solo a administradores.",
   "portal": "Portal de administración",

--- a/apps/admin/locales/fr/admin.json
+++ b/apps/admin/locales/fr/admin.json
@@ -1,5 +1,7 @@
 {
   "loading": "Chargement...",
+  "redirecting": "Redirection vers la connexion...",
+  "login_url_missing": "L'URL de l'application client n'est pas configurée.",
   "access_denied": "Accès refusé",
   "admin_only": "Cette zone est réservée aux administrateurs.",
   "portal": "Portail d'administration",

--- a/apps/admin/server.ts
+++ b/apps/admin/server.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 import { serve } from "bun";
 import { createRequestHandler } from "react-router";
+import { injectPublicAppConfigIntoResponse } from "shared/config/public-app-urls";
 
 const port = Number(process.env.PORT) || 5175;
 const host = process.env.HOST || "0.0.0.0";
@@ -46,7 +47,8 @@ serve({
       }
 
       // Handle all other requests with React Router
-      return await handleRequest(request);
+      const response = await handleRequest(request);
+      return await injectPublicAppConfigIntoResponse(response);
     } catch (error) {
       console.error("Error handling request:", error);
       return new Response("Internal Server Error", { status: 500 });

--- a/apps/admin/src/components/AdminAuthGuard.test.tsx
+++ b/apps/admin/src/components/AdminAuthGuard.test.tsx
@@ -17,6 +17,7 @@ let i18nInstance: i18n;
 
 mock.module("@admin/lib/auth-client", () => ({
   useSession: () => sessionState,
+  signOut: () => undefined,
 }));
 
 let AdminAuthGuard: (props: { children: ReactNode }) => JSX.Element;

--- a/apps/admin/src/components/AdminAuthGuard.test.tsx
+++ b/apps/admin/src/components/AdminAuthGuard.test.tsx
@@ -102,11 +102,8 @@ describe("AdminAuthGuard", () => {
 
   test("does not redirect onto the admin app when the frontend URL is missing", () => {
     sessionState = { data: null, isPending: false };
-    window.__APP_CONFIG__ = {
-      FRONTEND_URL: "",
-      ADMIN_URL: "",
-      API_BASE_URL: "",
-    };
+    delete process.env.VITE_FRONTEND_URL;
+    window.__APP_CONFIG__ = undefined;
     const hrefBefore = window.location.href;
 
     const { getByText } = render(

--- a/apps/admin/src/components/AdminAuthGuard.test.tsx
+++ b/apps/admin/src/components/AdminAuthGuard.test.tsx
@@ -14,19 +14,15 @@ type SessionState =
 
 let sessionState: SessionState = { data: null, isPending: false };
 let i18nInstance: i18n;
-let loginUrl = "http://frontend.example.com/auth/login";
 
 mock.module("@admin/lib/auth-client", () => ({
   useSession: () => sessionState,
 }));
 
-mock.module("@admin/lib/public-urls", () => ({
-  getFrontendLoginUrl: () => loginUrl,
-  getFrontendUrl: () => loginUrl.replace(/\/auth\/login$/, ""),
-}));
-
 let AdminAuthGuard: (props: { children: ReactNode }) => JSX.Element;
 const originalHref = window.location.href;
+const originalFrontendUrl = process.env.VITE_FRONTEND_URL;
+const originalRuntimeConfig = window.__APP_CONFIG__;
 
 beforeAll(async () => {
   i18nInstance = i18next.createInstance();
@@ -51,12 +47,19 @@ beforeAll(async () => {
 
 beforeEach(() => {
   sessionState = { data: null, isPending: false };
-  loginUrl = "http://frontend.example.com/auth/login";
+  process.env.VITE_FRONTEND_URL = originalFrontendUrl ?? "http://frontend.example.com";
+  window.__APP_CONFIG__ = undefined;
   window.location.href = originalHref;
 });
 
 afterEach(() => {
   window.location.href = originalHref;
+  window.__APP_CONFIG__ = originalRuntimeConfig;
+  if (originalFrontendUrl === undefined) {
+    delete process.env.VITE_FRONTEND_URL;
+  } else {
+    process.env.VITE_FRONTEND_URL = originalFrontendUrl;
+  }
 });
 
 describe("AdminAuthGuard", () => {
@@ -80,6 +83,9 @@ describe("AdminAuthGuard", () => {
 
   test("redirects to login when unauthenticated", async () => {
     sessionState = { data: null, isPending: false };
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "http://frontend.example.com",
+    };
 
     const { getByText } = render(
       <I18nextProvider i18n={i18nInstance}>
@@ -95,7 +101,11 @@ describe("AdminAuthGuard", () => {
 
   test("does not redirect onto the admin app when the frontend URL is missing", () => {
     sessionState = { data: null, isPending: false };
-    loginUrl = "";
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    };
     const hrefBefore = window.location.href;
 
     const { getByText } = render(

--- a/apps/admin/src/components/AdminAuthGuard.test.tsx
+++ b/apps/admin/src/components/AdminAuthGuard.test.tsx
@@ -14,9 +14,15 @@ type SessionState =
 
 let sessionState: SessionState = { data: null, isPending: false };
 let i18nInstance: i18n;
+let loginUrl = "http://frontend.example.com/auth/login";
 
 mock.module("@admin/lib/auth-client", () => ({
   useSession: () => sessionState,
+}));
+
+mock.module("@admin/lib/public-urls", () => ({
+  getFrontendLoginUrl: () => loginUrl,
+  getFrontendUrl: () => loginUrl.replace(/\/auth\/login$/, ""),
 }));
 
 let AdminAuthGuard: (props: { children: ReactNode }) => JSX.Element;
@@ -32,6 +38,7 @@ beforeAll(async () => {
         admin: {
           loading: "Loading...",
           redirecting: "Redirecting to login...",
+          login_url_missing: "Customer app URL is not configured.",
           access_denied: "Access Denied",
           admin_only: "This area is restricted to administrators only.",
         },
@@ -44,6 +51,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   sessionState = { data: null, isPending: false };
+  loginUrl = "http://frontend.example.com/auth/login";
   window.location.href = originalHref;
 });
 
@@ -80,7 +88,25 @@ describe("AdminAuthGuard", () => {
     );
 
     expect(getByText("Redirecting to login...")).toBeInTheDocument();
-    await waitFor(() => expect(window.location.href).toContain("/auth/login"));
+    await waitFor(() =>
+      expect(window.location.href).toBe("http://frontend.example.com/auth/login"),
+    );
+  });
+
+  test("does not redirect onto the admin app when the frontend URL is missing", () => {
+    sessionState = { data: null, isPending: false };
+    loginUrl = "";
+    const hrefBefore = window.location.href;
+
+    const { getByText } = render(
+      <I18nextProvider i18n={i18nInstance}>
+        <AdminAuthGuard>Child</AdminAuthGuard>
+      </I18nextProvider>,
+    );
+
+    expect(getByText("Customer app URL is not configured.")).toBeInTheDocument();
+    expect(window.location.href).toBe(hrefBefore);
+    expect(window.location.href).not.toContain("undefined");
   });
 
   test("renders children when the session belongs to an admin", () => {

--- a/apps/admin/src/components/AdminAuthGuard.tsx
+++ b/apps/admin/src/components/AdminAuthGuard.tsx
@@ -1,20 +1,20 @@
 import { useSession } from "@admin/lib/auth-client";
+import { getFrontendLoginUrl } from "@admin/lib/public-urls";
 import { isAdminSession } from "frontend-common/auth";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-const loginUrl = `${import.meta.env.VITE_FRONTEND_URL}/auth/login`;
-
 export const AdminAuthGuard = ({ children }: { children: ReactNode }) => {
   const { data: session, isPending } = useSession();
   const { t } = useTranslation("admin");
+  const loginUrl = getFrontendLoginUrl();
 
   useEffect(() => {
-    if (!isPending && !session && typeof window !== "undefined") {
+    if (!isPending && !session && loginUrl && typeof window !== "undefined") {
       window.location.href = loginUrl;
     }
-  }, [isPending, session]);
+  }, [isPending, session, loginUrl]);
 
   if (isPending) {
     return (
@@ -31,7 +31,7 @@ export const AdminAuthGuard = ({ children }: { children: ReactNode }) => {
       <div className="flex min-h-screen items-center justify-center bg-background">
         <div className="text-center">
           <div className="text-lg text-foreground">
-            {t("redirecting", "Redirecting to login...")}
+            {loginUrl ? t("redirecting") : t("login_url_missing")}
           </div>
         </div>
       </div>

--- a/apps/admin/src/components/AdminSidebar.test.tsx
+++ b/apps/admin/src/components/AdminSidebar.test.tsx
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/matchers";
+import "@testing-library/jest-dom/vitest";
+import i18next, { type i18n } from "i18next";
+import type { JSX } from "react";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { MemoryRouter } from "react-router";
+
+mock.module("@admin/lib/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { email: "admin@example.com" } },
+  }),
+  signOut: () => undefined,
+}));
+
+mock.module("@admin/lib/public-urls", () => ({
+  getFrontendUrl: () => "https://demo-fullstackbun.estepanov.com",
+}));
+
+mock.module("./LanguageSelector", () => ({
+  LanguageSelector: () => null,
+}));
+
+let AdminSidebar: (props: Record<string, never>) => JSX.Element;
+let i18nInstance: i18n;
+
+beforeAll(async () => {
+  i18nInstance = i18next.createInstance();
+  await i18nInstance.use(initReactI18next).init({
+    lng: "en",
+    fallbackLng: "en",
+    resources: {
+      en: {
+        admin: {
+          navigation: {
+            dashboard: "Dashboard",
+            notifications: "Notifications",
+            users: "Users",
+            banned_users: "Banned Users",
+            frontend_app: "Back to App",
+            close_menu: "Close menu",
+          },
+          sign_out: "Sign Out",
+        },
+        color_mode_toggle: {
+          label: "Color mode",
+          current_mode: "Current mode",
+          options: {
+            light: "Light",
+            dark: "Dark",
+            system: "System",
+          },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+  ({ AdminSidebar } = await import("./AdminSidebar"));
+});
+
+describe("AdminSidebar", () => {
+  test("Back to App points at the customer frontend origin", () => {
+    const { getByRole } = render(
+      <I18nextProvider i18n={i18nInstance}>
+        <MemoryRouter>
+          <AdminSidebar />
+        </MemoryRouter>
+      </I18nextProvider>,
+    );
+
+    expect(getByRole("link", { name: "Back to App" })).toHaveAttribute(
+      "href",
+      "https://demo-fullstackbun.estepanov.com",
+    );
+  });
+});

--- a/apps/admin/src/components/AdminSidebar.test.tsx
+++ b/apps/admin/src/components/AdminSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 import { render } from "@testing-library/react";
 import "@testing-library/jest-dom/matchers";
 import "@testing-library/jest-dom/vitest";
@@ -14,16 +14,14 @@ mock.module("@admin/lib/auth-client", () => ({
   signOut: () => undefined,
 }));
 
-mock.module("@admin/lib/public-urls", () => ({
-  getFrontendUrl: () => "https://demo-fullstackbun.estepanov.com",
-}));
-
 mock.module("./LanguageSelector", () => ({
   LanguageSelector: () => null,
 }));
 
 let AdminSidebar: (props: Record<string, never>) => JSX.Element;
 let i18nInstance: i18n;
+const originalFrontendUrl = process.env.VITE_FRONTEND_URL;
+const originalRuntimeConfig = window.__APP_CONFIG__;
 
 beforeAll(async () => {
   i18nInstance = i18next.createInstance();
@@ -59,8 +57,22 @@ beforeAll(async () => {
   ({ AdminSidebar } = await import("./AdminSidebar"));
 });
 
+afterEach(() => {
+  window.__APP_CONFIG__ = originalRuntimeConfig;
+  if (originalFrontendUrl === undefined) {
+    delete process.env.VITE_FRONTEND_URL;
+  } else {
+    process.env.VITE_FRONTEND_URL = originalFrontendUrl;
+  }
+});
+
 describe("AdminSidebar", () => {
   test("Back to App points at the customer frontend origin", () => {
+    process.env.VITE_FRONTEND_URL = "https://demo-fullstackbun.estepanov.com";
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "https://demo-fullstackbun.estepanov.com",
+    };
+
     const { getByRole } = render(
       <I18nextProvider i18n={i18nInstance}>
         <MemoryRouter>

--- a/apps/admin/src/components/AdminSidebar.tsx
+++ b/apps/admin/src/components/AdminSidebar.tsx
@@ -1,5 +1,6 @@
 import { APP_NAME } from "@admin/app.config";
 import { signOut, useSession } from "@admin/lib/auth-client";
+import { getFrontendUrl } from "@admin/lib/public-urls";
 import { Button, ModeToggle, type ModeToggleCopy } from "frontend-common/components/ui";
 import {
   ArrowLeftFromLine,
@@ -47,7 +48,7 @@ export const AdminSidebar = ({
   const { t } = useTranslation("admin");
   const { t: tColorMode } = useTranslation("color_mode_toggle");
   const { data: session } = useSession();
-  const frontendUrl = import.meta.env.VITE_FRONTEND_URL;
+  const frontendUrl = getFrontendUrl();
   const modeToggleCopy: ModeToggleCopy = {
     label: tColorMode("label"),
     currentModeLabel: tColorMode("current_mode"),
@@ -131,16 +132,18 @@ export const AdminSidebar = ({
             <ModeToggle copy={modeToggleCopy} />
           </div>
         </div>
-        <Button asChild variant="outline" size="sm" className="w-full">
-          <a
-            href={frontendUrl}
-            onClick={() => onNavigate?.()}
-            className="flex items-center gap-2"
-          >
-            <ArrowLeftFromLine className="h-4 w-4" />
-            {t("navigation.frontend_app")}
-          </a>
-        </Button>
+        {frontendUrl ? (
+          <Button asChild variant="outline" size="sm" className="w-full">
+            <a
+              href={frontendUrl}
+              onClick={() => onNavigate?.()}
+              className="flex items-center gap-2"
+            >
+              <ArrowLeftFromLine className="h-4 w-4" />
+              {t("navigation.frontend_app")}
+            </a>
+          </Button>
+        ) : null}
         <Button
           variant="outline"
           size="sm"

--- a/apps/admin/src/lib/public-urls.test.ts
+++ b/apps/admin/src/lib/public-urls.test.ts
@@ -25,11 +25,8 @@ describe("admin public URLs", () => {
   });
 
   test("does not build undefined/auth/login when the frontend origin is missing", () => {
-    window.__APP_CONFIG__ = {
-      FRONTEND_URL: "",
-      ADMIN_URL: "",
-      API_BASE_URL: "",
-    };
+    delete process.env.VITE_FRONTEND_URL;
+    window.__APP_CONFIG__ = undefined;
 
     expect(getFrontendUrl()).toBe("");
     expect(getFrontendLoginUrl()).toBe("");

--- a/apps/admin/src/lib/public-urls.test.ts
+++ b/apps/admin/src/lib/public-urls.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getFrontendLoginUrl, getFrontendUrl } from "./public-urls";
+
+const originalFrontendUrl = process.env.VITE_FRONTEND_URL;
+const originalRuntimeConfig = window.__APP_CONFIG__;
+
+afterEach(() => {
+  if (originalFrontendUrl === undefined) {
+    delete process.env.VITE_FRONTEND_URL;
+  } else {
+    process.env.VITE_FRONTEND_URL = originalFrontendUrl;
+  }
+  window.__APP_CONFIG__ = originalRuntimeConfig;
+});
+
+describe("admin public URLs", () => {
+  test("uses the deployed frontend origin instead of a relative path", () => {
+    process.env.VITE_FRONTEND_URL = "https://demo-fullstackbun.estepanov.com/";
+    window.__APP_CONFIG__ = undefined;
+
+    expect(getFrontendUrl()).toBe("https://demo-fullstackbun.estepanov.com");
+    expect(getFrontendLoginUrl()).toBe(
+      "https://demo-fullstackbun.estepanov.com/auth/login",
+    );
+  });
+
+  test("does not build undefined/auth/login when the frontend origin is missing", () => {
+    delete process.env.VITE_FRONTEND_URL;
+    delete process.env.FRONTEND_URL;
+    delete process.env.FE_BASE_URL;
+    window.__APP_CONFIG__ = undefined;
+
+    expect(getFrontendUrl()).toBe("");
+    expect(getFrontendLoginUrl()).toBe("");
+    expect(getFrontendLoginUrl()).not.toContain("undefined");
+  });
+
+  test("prefers runtime config injected by the production server", () => {
+    process.env.VITE_FRONTEND_URL = "https://build-time.example.com";
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "https://demo-fullstackbun.estepanov.com",
+    };
+
+    expect(getFrontendUrl()).toBe("https://demo-fullstackbun.estepanov.com");
+  });
+});

--- a/apps/admin/src/lib/public-urls.test.ts
+++ b/apps/admin/src/lib/public-urls.test.ts
@@ -25,10 +25,11 @@ describe("admin public URLs", () => {
   });
 
   test("does not build undefined/auth/login when the frontend origin is missing", () => {
-    delete process.env.VITE_FRONTEND_URL;
-    delete process.env.FRONTEND_URL;
-    delete process.env.FE_BASE_URL;
-    window.__APP_CONFIG__ = undefined;
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    };
 
     expect(getFrontendUrl()).toBe("");
     expect(getFrontendLoginUrl()).toBe("");

--- a/apps/admin/src/lib/public-urls.ts
+++ b/apps/admin/src/lib/public-urls.ts
@@ -1,10 +1,9 @@
 import { joinPublicUrl, resolvePublicAppConfig } from "shared/config/public-app-urls";
 
-const buildTimeConfig = {
-  FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL,
-  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
-};
-
-export const getFrontendUrl = () => resolvePublicAppConfig(buildTimeConfig).FRONTEND_URL;
+export const getFrontendUrl = () =>
+  resolvePublicAppConfig({
+    FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL,
+    API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+  }).FRONTEND_URL;
 
 export const getFrontendLoginUrl = () => joinPublicUrl(getFrontendUrl(), "/auth/login");

--- a/apps/admin/src/lib/public-urls.ts
+++ b/apps/admin/src/lib/public-urls.ts
@@ -1,0 +1,10 @@
+import { joinPublicUrl, resolvePublicAppConfig } from "shared/config/public-app-urls";
+
+const buildTimeConfig = {
+  FRONTEND_URL: import.meta.env.VITE_FRONTEND_URL,
+  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+};
+
+export const getFrontendUrl = () => resolvePublicAppConfig(buildTimeConfig).FRONTEND_URL;
+
+export const getFrontendLoginUrl = () => joinPublicUrl(getFrontendUrl(), "/auth/login");

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,8 +1,45 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { copyTranslationsPlugin } from "./src/lib/vite-i18n-plugin";
+
+const adminDir = dirname(fileURLToPath(import.meta.url));
+
+const applyDemoEnvFromFile = () => {
+  if (process.env.VITE_ADMIN_DEMO !== "true") {
+    return;
+  }
+
+  const envPath = resolve(adminDir, ".env.demo");
+  if (!existsSync(envPath)) {
+    return;
+  }
+
+  for (const line of readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const equalsIndex = trimmed.indexOf("=");
+    if (equalsIndex === -1) {
+      continue;
+    }
+    const key = trimmed.slice(0, equalsIndex).trim();
+    const rawValue = trimmed.slice(equalsIndex + 1).trim();
+    const value = rawValue.replace(/^["']|["']$/g, "");
+    if (key) {
+      // Demo builds must use .env.demo even if the host (e.g. Cloudflare Pages)
+      // still has stale VITE_* values in the dashboard.
+      process.env[key] = value;
+    }
+  }
+};
+
+applyDemoEnvFromFile();
 
 // https://vite.dev/config/
 export default defineConfig(({ command }) => {

--- a/apps/docs/docker.md
+++ b/apps/docs/docker.md
@@ -6,6 +6,7 @@ This guide explains how to use Docker to run the fullstack-bun monorepo in both 
 
 This monorepo contains:
 - **Frontend**: React app with Vite and React Router
+- **Admin**: Internal administration panel
 - **API**: Hono server running on Bun
 - **PostgreSQL**: Database service
 - **Redis**: Cache/session store
@@ -45,6 +46,7 @@ docker-compose up --build
 
 This will start:
 - Frontend on http://localhost:5173 (HMR on :5174)
+- Admin on http://localhost:5175 (HMR on :5176)
 - API on http://localhost:3001
 - PostgreSQL on localhost:5432
 - Redis on localhost:6379
@@ -115,6 +117,7 @@ docker-compose -f docker-compose.prod.yml down
 This will:
 - Build optimized production images
 - Run frontend on http://localhost:5173
+- Run admin on http://localhost:5175
 - Run API on http://localhost:3001
 - Keep PostgreSQL and Redis isolated on the internal Docker network (access via `docker-compose exec`)
 
@@ -143,10 +146,13 @@ REDIS_PASSWORD=your_secure_redis_password_here
 # Application Ports
 API_PORT=3001
 FRONTEND_PORT=5173
+ADMIN_PORT=5175
 
 # Production Configuration
-CORS_ALLOWLISTED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+CORS_ALLOWLISTED_ORIGINS=https://yourdomain.com,https://admin.yourdomain.com
 VITE_API_BASE_URL=https://api.yourdomain.com
+VITE_ADMIN_URL=https://admin.yourdomain.com
+VITE_FRONTEND_URL=https://yourdomain.com
 ```
 
 **Important**: Always use strong passwords and secure values in production!

--- a/apps/docs/flyio.md
+++ b/apps/docs/flyio.md
@@ -364,7 +364,7 @@ fly deploy --app fullstack-bun-frontend --config apps/frontend/fly.toml \
 ::: warning Build Args vs Runtime
 `VITE_*` variables are compiled into the JavaScript bundle at build time. `VITE_API_BASE_URL` still requires a rebuild if you change the API origin.
 
-`VITE_ADMIN_URL` (frontend) and `VITE_FRONTEND_URL` (admin) are also read at runtime by the production servers and injected as `window.__APP_CONFIG__`. Set them in `[env]` or as Fly secrets if you need to correct cross-app links without rebuilding.
+Cross-app links (`VITE_ADMIN_URL` on frontend, `VITE_FRONTEND_URL` on admin) can also be set as runtime `[env]` or Fly secrets to override the baked origin without rebuilding. Do **not** leave template `yourdomain.com` placeholders in `[env]` — they override per-deploy `--build-arg` values. The shipped `fly.toml` files keep those keys in `[build.args]` only; empty runtime values fall through to the build-time URLs.
 :::
 
 #### 3. Deploy
@@ -1080,7 +1080,7 @@ bun --filter=api run db:rollback
 - Environment variables unchanged after redeploy
 
 **Cause:**
-`VITE_API_BASE_URL` is compiled at build time. Cross-app links (`VITE_ADMIN_URL`, `VITE_FRONTEND_URL`) can also be set as runtime `[env]` values without a rebuild.
+`VITE_API_BASE_URL` is compiled at build time. Cross-app links (`VITE_ADMIN_URL`, `VITE_FRONTEND_URL`) can optionally be set as runtime `[env]` values without a rebuild. Only set those `[env]` keys to real origins — template placeholders override `--build-arg` URLs.
 
 **Solution:**
 For API URL changes, force rebuild with updated args:

--- a/apps/docs/flyio.md
+++ b/apps/docs/flyio.md
@@ -361,8 +361,10 @@ fly deploy --app fullstack-bun-frontend --config apps/frontend/fly.toml \
   --build-arg VITE_ADMIN_URL=https://admin.yourdomain.com
 ```
 
-::: warning Build Args vs Secrets
-`VITE_*` variables are **build arguments**, not runtime secrets. They're compiled into the JavaScript bundle at build time. If you change them, you must rebuild and redeploy.
+::: warning Build Args vs Runtime
+`VITE_*` variables are compiled into the JavaScript bundle at build time. `VITE_API_BASE_URL` still requires a rebuild if you change the API origin.
+
+`VITE_ADMIN_URL` (frontend) and `VITE_FRONTEND_URL` (admin) are also read at runtime by the production servers and injected as `window.__APP_CONFIG__`. Set them in `[env]` or as Fly secrets if you need to correct cross-app links without rebuilding.
 :::
 
 #### 3. Deploy
@@ -441,8 +443,8 @@ The admin app is configured with `min_machines_running = 0` to scale down when i
 | `GITHUB_CLIENT_ID` | API | Secret | GitHub OAuth ID (optional) |
 | `GITHUB_CLIENT_SECRET` | API | Secret | GitHub OAuth secret (optional) |
 | `VITE_API_BASE_URL` | Frontend, Admin | Build Arg | API URL (compiled at build time) |
-| `VITE_ADMIN_URL` | Frontend | Build Arg | Admin URL (compiled at build time) |
-| `VITE_FRONTEND_URL` | Admin | Build Arg | Frontend URL (compiled at build time) |
+| `VITE_ADMIN_URL` | Frontend | Build Arg + runtime env | Admin origin for header links |
+| `VITE_FRONTEND_URL` | Admin | Build Arg + runtime env | Frontend origin for "Back to App" |
 
 ### Setting Secrets
 
@@ -1078,10 +1080,10 @@ bun --filter=api run db:rollback
 - Environment variables unchanged after redeploy
 
 **Cause:**
-Build args are compiled at build time, not runtime.
+`VITE_API_BASE_URL` is compiled at build time. Cross-app links (`VITE_ADMIN_URL`, `VITE_FRONTEND_URL`) can also be set as runtime `[env]` values without a rebuild.
 
 **Solution:**
-Force rebuild with updated args:
+For API URL changes, force rebuild with updated args:
 
 ```bash
 fly deploy --app fullstack-bun-frontend --config apps/frontend/fly.toml \

--- a/apps/docs/reference/environment-variables.md
+++ b/apps/docs/reference/environment-variables.md
@@ -319,6 +319,8 @@ VITE_API_BASE_URL="http://localhost:3001"
 
 Like `VITE_ADMIN_URL`, this is compiled at build time **and** read at runtime by the admin server (`window.__APP_CONFIG__`). Set it to the **frontend** origin in deployed environments — if it is missing, "Back to App" used to resolve as a relative URL on the admin app itself.
 
+Demo/mock builds (`VITE_ADMIN_DEMO=true`) always apply `apps/admin/.env.demo`, including on Cloudflare Pages, so stale dashboard `VITE_*` values cannot point **Back to App** at the wrong host.
+
 ```txt
 VITE_FRONTEND_URL="http://localhost:5173"
 ```

--- a/apps/docs/reference/environment-variables.md
+++ b/apps/docs/reference/environment-variables.md
@@ -287,7 +287,7 @@ VITE_API_BASE_URL="http://localhost:3001"
 
 **Required in production.** Origin of the admin app. Used for the header "Admin" link.
 
-Vite compiles `VITE_*` values into the client bundle at **build** time. The production frontend server also reads this variable at **runtime** and injects it as `window.__APP_CONFIG__`, so Hostinger / Docker / Fly env vars work without a rebuild.
+Vite compiles `VITE_*` values into the client bundle at **build** time. The production frontend server also reads this variable at **runtime** and injects it as `window.__APP_CONFIG__`, so Hostinger / Docker / Fly env vars work without a rebuild. Empty or unset runtime values fall through to the origin baked into the bundle — do not ship placeholder URLs such as `https://admin.yourdomain.com` as runtime env.
 
 ```txt
 VITE_ADMIN_URL="http://localhost:5175"
@@ -317,7 +317,7 @@ VITE_API_BASE_URL="http://localhost:3001"
 
 **Required.** Origin of the customer-facing frontend (not the admin app). Used for the sidebar "Back to App" link and unauthenticated redirects to `/auth/login`.
 
-Like `VITE_ADMIN_URL`, this is compiled at build time **and** read at runtime by the admin server (`window.__APP_CONFIG__`). Set it to the **frontend** origin in deployed environments — if it is missing, "Back to App" used to resolve as a relative URL on the admin app itself.
+Like `VITE_ADMIN_URL`, this is compiled at build time **and** read at runtime by the admin server (`window.__APP_CONFIG__`). Set it to the **frontend** origin in deployed environments. If the runtime value is missing, the client keeps the build-time origin instead of building `undefined/auth/login`. Do not ship placeholder URLs such as `https://yourdomain.com` as runtime env when you already customized `[build.args]`.
 
 Demo/mock builds (`VITE_ADMIN_DEMO=true`) always apply `apps/admin/.env.demo`, including on Cloudflare Pages, so stale dashboard `VITE_*` values cannot point **Back to App** at the wrong host.
 

--- a/apps/docs/reference/environment-variables.md
+++ b/apps/docs/reference/environment-variables.md
@@ -283,6 +283,20 @@ The `.env` for `/apps/frontend`
 VITE_API_BASE_URL="http://localhost:3001"
 ```
 
+### `VITE_ADMIN_URL`
+
+**Required in production.** Origin of the admin app. Used for the header "Admin" link.
+
+Vite compiles `VITE_*` values into the client bundle at **build** time. The production frontend server also reads this variable at **runtime** and injects it as `window.__APP_CONFIG__`, so Hostinger / Docker / Fly env vars work without a rebuild.
+
+```txt
+VITE_ADMIN_URL="http://localhost:5175"
+```
+
+```txt
+VITE_ADMIN_URL="https://admin.yourdomain.com"
+```
+
 ### `NODE_ENV`
 
 In local development `development` and for all static builds it should be `production`
@@ -301,10 +315,16 @@ VITE_API_BASE_URL="http://localhost:3001"
 
 ### `VITE_FRONTEND_URL`
 
-**Required.** Base URL for the main frontend app (used for linking back).
+**Required.** Origin of the customer-facing frontend (not the admin app). Used for the sidebar "Back to App" link and unauthenticated redirects to `/auth/login`.
+
+Like `VITE_ADMIN_URL`, this is compiled at build time **and** read at runtime by the admin server (`window.__APP_CONFIG__`). Set it to the **frontend** origin in deployed environments — if it is missing, "Back to App" used to resolve as a relative URL on the admin app itself.
 
 ```txt
 VITE_FRONTEND_URL="http://localhost:5173"
+```
+
+```txt
+VITE_FRONTEND_URL="https://yourdomain.com"
 ```
 
 ### `VITE_ADMIN_DEMO`
@@ -322,4 +342,5 @@ In local development `development` and for all static builds it should be `produ
 ## Notes on Docker vs Local
 
 - Docker Compose loads env from the repo root `.env` plus `apps/api/.env` and `apps/frontend/.env`.
+- Production Compose (`docker-compose.prod.yml`) also builds and runs the admin app. Set `VITE_ADMIN_URL` and `VITE_FRONTEND_URL` in the root `.env` so the apps link to each other instead of localhost.
 - For local (non-Docker) development, only the app-specific `.env` files matter.

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -98,6 +98,7 @@ COPY --from=build --chown=bunapp:bunapp /app/node_modules ./node_modules
 COPY --from=build --chown=bunapp:bunapp /app/apps/frontend/node_modules ./apps/frontend/node_modules
 COPY --from=build --chown=bunapp:bunapp /app/apps/frontend/build ./apps/frontend/build
 COPY --from=build --chown=bunapp:bunapp /app/apps/frontend/server.ts ./apps/frontend/server.ts
+COPY --from=build --chown=bunapp:bunapp /app/packages ./packages
 # Drop privileges for runtime
 USER bunapp
 # Expose production port

--- a/apps/frontend/fly.toml
+++ b/apps/frontend/fly.toml
@@ -14,12 +14,13 @@ primary_region = 'iad'
     VITE_API_BASE_URL = 'https://api.yourdomain.com'
     VITE_ADMIN_URL = 'https://admin.yourdomain.com'
 
-# Environment variables (public, non-sensitive)
+# Environment variables (public, non-sensitive).
+# Keep VITE_* out of [env] — placeholder values would override per-deploy
+# [build.args] / --build-arg URLs via window.__APP_CONFIG__. Set runtime
+# VITE_ADMIN_URL only when you intentionally want to override the baked origin.
 [env]
   PORT = '5173'
   NODE_ENV = 'production'
-  VITE_API_BASE_URL = 'https://api.yourdomain.com'
-  VITE_ADMIN_URL = 'https://admin.yourdomain.com'
 
 # HTTP service configuration
 [[services]]

--- a/apps/frontend/fly.toml
+++ b/apps/frontend/fly.toml
@@ -18,6 +18,8 @@ primary_region = 'iad'
 [env]
   PORT = '5173'
   NODE_ENV = 'production'
+  VITE_API_BASE_URL = 'https://api.yourdomain.com'
+  VITE_ADMIN_URL = 'https://admin.yourdomain.com'
 
 # HTTP service configuration
 [[services]]

--- a/apps/frontend/server.ts
+++ b/apps/frontend/server.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 import { serve } from "bun";
 import { createRequestHandler } from "react-router";
+import { injectPublicAppConfigIntoResponse } from "shared/config/public-app-urls";
 
 const port = Number(process.env.PORT) || 5173;
 const host = process.env.HOST || "0.0.0.0";
@@ -46,7 +47,8 @@ serve({
       }
 
       // Handle all other requests with React Router
-      return await handleRequest(request);
+      const response = await handleRequest(request);
+      return await injectPublicAppConfigIntoResponse(response);
     } catch (error) {
       console.error("Error handling request:", error);
       return new Response("Internal Server Error", { status: 500 });

--- a/apps/frontend/src/components/Header.tsx
+++ b/apps/frontend/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { signOut, useSession } from "@frontend/lib/auth-client";
 import { getInitials } from "@frontend/lib/getInitials";
+import { getAdminUrl } from "@frontend/lib/public-urls";
 import { PopoverClose } from "@radix-ui/react-popover";
 import { isAdminSession } from "frontend-common/auth";
 import {
@@ -39,7 +40,7 @@ const NavLink = ({
     </RouterNavLink>
   );
 };
-const MobileNavigation = () => {
+const MobileNavigation = ({ adminUrl }: { adminUrl: string }) => {
   const { t } = useTranslation("header");
   const { data: session } = useSession();
   const isAdmin = isAdminSession(session);
@@ -66,14 +67,11 @@ const MobileNavigation = () => {
             <NavLink to="/dashboard">{t("nav_links.dashboard")}</NavLink>
           </PopoverClose>
         )}
-        {isAdmin && (
-          <a
-            href={import.meta.env.VITE_ADMIN_URL || "http://localhost:5175"}
-            className="hover:underline"
-          >
+        {isAdmin && adminUrl ? (
+          <a href={adminUrl} className="hover:underline">
             {t("nav_links.admin")}
           </a>
-        )}
+        ) : null}
         <Separator className="my-2" />
         {session ? (
           <div className="flex flex-col gap-2">
@@ -98,6 +96,7 @@ export const Header = () => {
   const { t } = useTranslation("header");
   const { data: session } = useSession();
   const isAdmin = isAdminSession(session);
+  const adminUrl = getAdminUrl();
   const userName = session?.user.name?.trim() || session?.user.email || "";
   const avatarAltName = userName || session?.user.email || t("user_menu.fallback_name");
   const avatarAlt = t("user_menu.avatar_alt", { name: avatarAltName });
@@ -119,14 +118,11 @@ export const Header = () => {
             <div className="hidden md:flex md:gap-x-6">
               <NavLink to="/more">{t("nav_links.second_page")}</NavLink>
               {session && <NavLink to="/dashboard">{t("nav_links.dashboard")}</NavLink>}
-              {isAdmin && (
-                <a
-                  href={import.meta.env.VITE_ADMIN_URL || "http://localhost:5175"}
-                  className="hover:underline"
-                >
+              {isAdmin && adminUrl ? (
+                <a href={adminUrl} className="hover:underline">
                   {t("nav_links.admin")}
                 </a>
-              )}
+              ) : null}
             </div>
           </div>
           <div className="flex items-center gap-x-2">
@@ -191,7 +187,7 @@ export const Header = () => {
               </StyledLink>
             )}
             <div className="-mr-1 md:hidden">
-              <MobileNavigation />
+              <MobileNavigation adminUrl={adminUrl} />
             </div>
           </div>
         </nav>

--- a/apps/frontend/src/lib/public-urls.test.ts
+++ b/apps/frontend/src/lib/public-urls.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getAdminUrl } from "./public-urls";
+
+const originalAdminUrl = process.env.VITE_ADMIN_URL;
+const originalRuntimeConfig = window.__APP_CONFIG__;
+
+afterEach(() => {
+  if (originalAdminUrl === undefined) {
+    delete process.env.VITE_ADMIN_URL;
+  } else {
+    process.env.VITE_ADMIN_URL = originalAdminUrl;
+  }
+  window.__APP_CONFIG__ = originalRuntimeConfig;
+});
+
+describe("frontend public URLs", () => {
+  test("uses the deployed admin origin instead of localhost", () => {
+    process.env.VITE_ADMIN_URL = "https://demo-admin-fullstackbun.estepanov.com/";
+    window.__APP_CONFIG__ = undefined;
+
+    expect(getAdminUrl()).toBe("https://demo-admin-fullstackbun.estepanov.com");
+    expect(getAdminUrl()).not.toContain("localhost");
+  });
+
+  test("prefers runtime config injected by the production server", () => {
+    process.env.VITE_ADMIN_URL = "https://build-time-admin.example.com";
+    window.__APP_CONFIG__ = {
+      ADMIN_URL: "https://demo-admin-fullstackbun.estepanov.com",
+    };
+
+    expect(getAdminUrl()).toBe("https://demo-admin-fullstackbun.estepanov.com");
+  });
+});

--- a/apps/frontend/src/lib/public-urls.ts
+++ b/apps/frontend/src/lib/public-urls.ts
@@ -1,14 +1,12 @@
 import { resolvePublicAppConfig } from "shared/config/public-app-urls";
 
-const buildTimeConfig = {
-  ADMIN_URL: import.meta.env.VITE_ADMIN_URL,
-  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
-};
-
 const isViteDev = import.meta.env.DEV === true;
 
 export const getAdminUrl = () => {
-  const configured = resolvePublicAppConfig(buildTimeConfig).ADMIN_URL;
+  const configured = resolvePublicAppConfig({
+    ADMIN_URL: import.meta.env.VITE_ADMIN_URL,
+    API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+  }).ADMIN_URL;
   if (configured) {
     return configured;
   }

--- a/apps/frontend/src/lib/public-urls.ts
+++ b/apps/frontend/src/lib/public-urls.ts
@@ -1,0 +1,16 @@
+import { resolvePublicAppConfig } from "shared/config/public-app-urls";
+
+const buildTimeConfig = {
+  ADMIN_URL: import.meta.env.VITE_ADMIN_URL,
+  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+};
+
+const isViteDev = import.meta.env.DEV === true;
+
+export const getAdminUrl = () => {
+  const configured = resolvePublicAppConfig(buildTimeConfig).ADMIN_URL;
+  if (configured) {
+    return configured;
+  }
+  return isViteDev ? "http://localhost:5175" : "";
+};

--- a/apps/frontend/src/vite-env.d.ts
+++ b/apps/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
+  readonly VITE_ADMIN_URL?: string;
 }
 
 interface ImportMeta {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,26 @@ services:
         condition: service_healthy
     restart: always
 
+  admin:
+    build:
+      context: .
+      dockerfile: apps/admin/Dockerfile
+      target: production
+      args:
+        - VITE_API_BASE_URL=${VITE_API_BASE_URL:-http://localhost:3001}
+        - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost:5173}
+    container_name: myapp-admin-prod
+    ports:
+      - "${ADMIN_PORT:-5175}:5175"
+    environment:
+      - NODE_ENV=production
+      - VITE_API_BASE_URL=${VITE_API_BASE_URL:-http://localhost:3001}
+      - VITE_FRONTEND_URL=${VITE_FRONTEND_URL:-http://localhost:5173}
+    depends_on:
+      api:
+        condition: service_healthy
+    restart: always
+
 volumes:
   postgres-data:
   redis-data:

--- a/packages/shared/config/public-app-urls.test.ts
+++ b/packages/shared/config/public-app-urls.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  firstPublicUrl,
+  injectPublicAppConfig,
+  injectPublicAppConfigIntoResponse,
+  joinPublicUrl,
+  normalizePublicUrl,
+  publicAppConfigFromEnv,
+  resolvePublicAppConfig,
+  serializePublicAppConfigScript,
+} from "./public-app-urls";
+
+const originalRuntimeConfig = window.__APP_CONFIG__;
+
+afterEach(() => {
+  window.__APP_CONFIG__ = originalRuntimeConfig;
+});
+
+describe("normalizePublicUrl", () => {
+  test("trims whitespace and trailing slashes", () => {
+    expect(normalizePublicUrl(" https://app.example.com/ ")).toBe(
+      "https://app.example.com",
+    );
+    expect(normalizePublicUrl("https://app.example.com///")).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  test("returns empty string for missing values", () => {
+    expect(normalizePublicUrl(undefined)).toBe("");
+    expect(normalizePublicUrl("   ")).toBe("");
+  });
+});
+
+describe("firstPublicUrl", () => {
+  test("skips empty candidates", () => {
+    expect(firstPublicUrl("", undefined, " https://admin.example.com/ ")).toBe(
+      "https://admin.example.com",
+    );
+  });
+});
+
+describe("joinPublicUrl", () => {
+  test("returns empty when the base origin is missing", () => {
+    expect(joinPublicUrl("", "/auth/login")).toBe("");
+    expect(joinPublicUrl(undefined as unknown as string, "/auth/login")).toBe("");
+  });
+
+  test("joins an origin and path without duplicating slashes", () => {
+    expect(joinPublicUrl("https://app.example.com/", "/auth/login")).toBe(
+      "https://app.example.com/auth/login",
+    );
+  });
+});
+
+describe("publicAppConfigFromEnv", () => {
+  test("prefers VITE_ keys and accepts unprefixed aliases", () => {
+    expect(
+      publicAppConfigFromEnv({
+        VITE_FRONTEND_URL: "https://app.example.com/",
+        FRONTEND_URL: "https://ignored.example.com",
+        ADMIN_URL: "https://admin.example.com",
+        API_BASE_URL: "https://api.example.com",
+      }),
+    ).toEqual({
+      FRONTEND_URL: "https://app.example.com",
+      ADMIN_URL: "https://admin.example.com",
+      API_BASE_URL: "https://api.example.com",
+    });
+  });
+});
+
+describe("resolvePublicAppConfig", () => {
+  test("runtime window config wins over env and build-time values", () => {
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "https://runtime-app.example.com/",
+      ADMIN_URL: "https://runtime-admin.example.com",
+    };
+
+    expect(
+      resolvePublicAppConfig(
+        {
+          FRONTEND_URL: "https://build-app.example.com",
+          ADMIN_URL: "https://build-admin.example.com",
+        },
+        {
+          VITE_FRONTEND_URL: "https://env-app.example.com",
+          VITE_ADMIN_URL: "https://env-admin.example.com",
+        },
+      ),
+    ).toEqual({
+      FRONTEND_URL: "https://runtime-app.example.com",
+      ADMIN_URL: "https://runtime-admin.example.com",
+      API_BASE_URL: "",
+    });
+  });
+
+  test("falls back to env then build-time when runtime config is absent", () => {
+    window.__APP_CONFIG__ = undefined;
+
+    expect(
+      resolvePublicAppConfig(
+        { FRONTEND_URL: "https://build-app.example.com" },
+        { VITE_ADMIN_URL: "https://env-admin.example.com/" },
+      ),
+    ).toEqual({
+      FRONTEND_URL: "https://build-app.example.com",
+      ADMIN_URL: "https://env-admin.example.com",
+      API_BASE_URL: "",
+    });
+  });
+});
+
+describe("injectPublicAppConfig", () => {
+  test("inserts a script tag immediately after <head>", () => {
+    const html = "<html><head><title>Admin</title></head><body></body></html>";
+    const injected = injectPublicAppConfig(html, {
+      FRONTEND_URL: "https://app.example.com",
+      ADMIN_URL: "https://admin.example.com",
+      API_BASE_URL: "https://api.example.com",
+    });
+
+    expect(injected.startsWith("<html><head><script>window.__APP_CONFIG__=")).toBe(true);
+    expect(injected).toContain('"FRONTEND_URL":"https://app.example.com"');
+    expect(injected).toContain("<title>Admin</title>");
+  });
+
+  test("does not inject twice", () => {
+    const html = "<head></head>";
+    const first = injectPublicAppConfig(html, {
+      FRONTEND_URL: "https://app.example.com",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+    const second = injectPublicAppConfig(first, {
+      FRONTEND_URL: "https://other.example.com",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+    expect(second).toBe(first);
+  });
+
+  test("escapes </script> breakout in serialized values", () => {
+    const script = serializePublicAppConfigScript({
+      FRONTEND_URL: "https://app.example.com/</script>",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+    expect(script).not.toContain("</script>");
+    expect(script).toContain("\\u003c/script>");
+  });
+});
+
+describe("injectPublicAppConfigIntoResponse", () => {
+  test("rewrites HTML responses and leaves other content types alone", async () => {
+    const htmlResponse = new Response("<head></head>", {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+    const rewritten = await injectPublicAppConfigIntoResponse(htmlResponse, {
+      FRONTEND_URL: "https://app.example.com",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+    expect(await rewritten.text()).toContain("window.__APP_CONFIG__=");
+
+    const jsonResponse = new Response("{}", {
+      headers: { "content-type": "application/json" },
+    });
+    const untouched = await injectPublicAppConfigIntoResponse(jsonResponse, {
+      FRONTEND_URL: "https://app.example.com",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+    expect(await untouched.text()).toBe("{}");
+  });
+});

--- a/packages/shared/config/public-app-urls.test.ts
+++ b/packages/shared/config/public-app-urls.test.ts
@@ -10,10 +10,13 @@ import {
   serializePublicAppConfigScript,
 } from "./public-app-urls";
 
-const originalRuntimeConfig = window.__APP_CONFIG__;
+const originalRuntimeConfig =
+  typeof window === "undefined" ? undefined : window.__APP_CONFIG__;
 
 afterEach(() => {
-  window.__APP_CONFIG__ = originalRuntimeConfig;
+  if (typeof window !== "undefined") {
+    window.__APP_CONFIG__ = originalRuntimeConfig;
+  }
 });
 
 describe("normalizePublicUrl", () => {
@@ -71,7 +74,7 @@ describe("publicAppConfigFromEnv", () => {
 });
 
 describe("resolvePublicAppConfig", () => {
-  test("runtime window config wins over env and build-time values", () => {
+  test("runtime window config is authoritative when injected", () => {
     window.__APP_CONFIG__ = {
       FRONTEND_URL: "https://runtime-app.example.com/",
       ADMIN_URL: "https://runtime-admin.example.com",
@@ -91,6 +94,25 @@ describe("resolvePublicAppConfig", () => {
     ).toEqual({
       FRONTEND_URL: "https://runtime-app.example.com",
       ADMIN_URL: "https://runtime-admin.example.com",
+      API_BASE_URL: "",
+    });
+  });
+
+  test("injected empty runtime values do not fall back to env or build-time", () => {
+    window.__APP_CONFIG__ = {
+      FRONTEND_URL: "",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    };
+
+    expect(
+      resolvePublicAppConfig(
+        { FRONTEND_URL: "https://build-app.example.com" },
+        { VITE_FRONTEND_URL: "https://env-app.example.com" },
+      ),
+    ).toEqual({
+      FRONTEND_URL: "",
+      ADMIN_URL: "",
       API_BASE_URL: "",
     });
   });
@@ -146,8 +168,8 @@ describe("injectPublicAppConfig", () => {
       ADMIN_URL: "",
       API_BASE_URL: "",
     });
-    expect(script).not.toContain("</script>");
     expect(script).toContain("\\u003c/script>");
+    expect(script.match(/<\/script>/g)?.length).toBe(1);
   });
 });
 

--- a/packages/shared/config/public-app-urls.test.ts
+++ b/packages/shared/config/public-app-urls.test.ts
@@ -74,7 +74,7 @@ describe("publicAppConfigFromEnv", () => {
 });
 
 describe("resolvePublicAppConfig", () => {
-  test("runtime window config is authoritative when injected", () => {
+  test("runtime window config is preferred when it has a real origin", () => {
     window.__APP_CONFIG__ = {
       FRONTEND_URL: "https://runtime-app.example.com/",
       ADMIN_URL: "https://runtime-admin.example.com",
@@ -98,7 +98,7 @@ describe("resolvePublicAppConfig", () => {
     });
   });
 
-  test("injected empty runtime values do not fall back to env or build-time", () => {
+  test("empty runtime values fall back to env then build-time", () => {
     window.__APP_CONFIG__ = {
       FRONTEND_URL: "",
       ADMIN_URL: "",
@@ -111,8 +111,24 @@ describe("resolvePublicAppConfig", () => {
         { VITE_FRONTEND_URL: "https://env-app.example.com" },
       ),
     ).toEqual({
+      FRONTEND_URL: "https://env-app.example.com",
+      ADMIN_URL: "",
+      API_BASE_URL: "",
+    });
+  });
+
+  test("empty runtime injection keeps customized build-time Fly link args", () => {
+    window.__APP_CONFIG__ = {
       FRONTEND_URL: "",
       ADMIN_URL: "",
+      API_BASE_URL: "",
+    };
+
+    expect(
+      resolvePublicAppConfig({ ADMIN_URL: "https://fullstack-bun-admin.fly.dev" }, {}),
+    ).toEqual({
+      FRONTEND_URL: "",
+      ADMIN_URL: "https://fullstack-bun-admin.fly.dev",
       API_BASE_URL: "",
     });
   });
@@ -174,25 +190,70 @@ describe("injectPublicAppConfig", () => {
 });
 
 describe("injectPublicAppConfigIntoResponse", () => {
+  const injectedConfig = {
+    FRONTEND_URL: "https://app.example.com",
+    ADMIN_URL: "",
+    API_BASE_URL: "",
+  };
+
   test("rewrites HTML responses and leaves other content types alone", async () => {
     const htmlResponse = new Response("<head></head>", {
-      headers: { "content-type": "text/html; charset=utf-8" },
+      headers: { "content-type": "text/html; charset=utf-8", "content-length": "13" },
     });
-    const rewritten = await injectPublicAppConfigIntoResponse(htmlResponse, {
-      FRONTEND_URL: "https://app.example.com",
-      ADMIN_URL: "",
-      API_BASE_URL: "",
-    });
+    const rewritten = injectPublicAppConfigIntoResponse(htmlResponse, injectedConfig);
+    expect(rewritten.headers.get("content-length")).toBeNull();
     expect(await rewritten.text()).toContain("window.__APP_CONFIG__=");
 
     const jsonResponse = new Response("{}", {
       headers: { "content-type": "application/json" },
     });
-    const untouched = await injectPublicAppConfigIntoResponse(jsonResponse, {
-      FRONTEND_URL: "https://app.example.com",
-      ADMIN_URL: "",
-      API_BASE_URL: "",
-    });
+    const untouched = injectPublicAppConfigIntoResponse(jsonResponse, injectedConfig);
     expect(await untouched.text()).toBe("{}");
+  });
+
+  test("injects after <head> without buffering the rest of a chunked HTML stream", async () => {
+    const encoder = new TextEncoder();
+    let releaseTail: (() => void) | undefined;
+    const tailReleased = new Promise<void>((resolve) => {
+      releaseTail = resolve;
+    });
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(encoder.encode("<html><he"));
+        controller.enqueue(encoder.encode("ad><title>App</title></head><body>"));
+        await tailReleased;
+        controller.enqueue(encoder.encode("tail</body></html>"));
+        controller.close();
+      },
+    });
+
+    const rewritten = injectPublicAppConfigIntoResponse(
+      new Response(stream, { headers: { "content-type": "text/html" } }),
+      injectedConfig,
+    );
+    const reader = rewritten.body?.getReader();
+    expect(reader).toBeDefined();
+    if (!reader) {
+      throw new Error("expected a readable body");
+    }
+
+    const first = await reader.read();
+    const firstText = new TextDecoder().decode(first.value);
+    expect(first.done).toBe(false);
+    expect(firstText).toContain("<head><script>window.__APP_CONFIG__=");
+    expect(firstText).toContain("<title>App</title>");
+    expect(firstText).not.toContain("tail");
+
+    releaseTail?.();
+    const remainingChunks: string[] = [];
+    while (true) {
+      const next = await reader.read();
+      if (next.done) {
+        break;
+      }
+      remainingChunks.push(new TextDecoder().decode(next.value));
+    }
+    expect(remainingChunks.join("")).toContain("tail</body></html>");
   });
 });

--- a/packages/shared/config/public-app-urls.ts
+++ b/packages/shared/config/public-app-urls.ts
@@ -5,6 +5,8 @@
  * Hostinger, Docker, and similar platforms often set the same keys only at
  * runtime. The Node servers inject `window.__APP_CONFIG__` from `process.env`
  * so cross-app links (e.g. admin "Back to App") follow the deployed origins.
+ * Empty injected values fall through to env and then to the Vite build-time
+ * origins, so Fly `[build.args]` still apply when `[env]` omits the URLs.
  */
 
 export const PUBLIC_APP_CONFIG_GLOBAL = "__APP_CONFIG__";
@@ -78,22 +80,20 @@ export const resolvePublicAppConfig = (
   buildTime: Partial<PublicAppConfig> = {},
   env: Record<string, string | undefined> = processEnv(),
 ): PublicAppConfig => {
-  const hasRuntime =
-    typeof window !== "undefined" && window[PUBLIC_APP_CONFIG_GLOBAL] !== undefined;
-  if (hasRuntime) {
-    const runtime = readRuntimePublicAppConfig();
-    return {
-      FRONTEND_URL: normalizePublicUrl(runtime.FRONTEND_URL),
-      ADMIN_URL: normalizePublicUrl(runtime.ADMIN_URL),
-      API_BASE_URL: normalizePublicUrl(runtime.API_BASE_URL),
-    };
-  }
-
+  const runtime = readRuntimePublicAppConfig();
   const fromEnv = publicAppConfigFromEnv(env);
   return {
-    FRONTEND_URL: firstPublicUrl(fromEnv.FRONTEND_URL, buildTime.FRONTEND_URL),
-    ADMIN_URL: firstPublicUrl(fromEnv.ADMIN_URL, buildTime.ADMIN_URL),
-    API_BASE_URL: firstPublicUrl(fromEnv.API_BASE_URL, buildTime.API_BASE_URL),
+    FRONTEND_URL: firstPublicUrl(
+      runtime.FRONTEND_URL,
+      fromEnv.FRONTEND_URL,
+      buildTime.FRONTEND_URL,
+    ),
+    ADMIN_URL: firstPublicUrl(runtime.ADMIN_URL, fromEnv.ADMIN_URL, buildTime.ADMIN_URL),
+    API_BASE_URL: firstPublicUrl(
+      runtime.API_BASE_URL,
+      fromEnv.API_BASE_URL,
+      buildTime.API_BASE_URL,
+    ),
   };
 };
 
@@ -119,19 +119,74 @@ export const injectPublicAppConfig = (
   return `${html.slice(0, insertAt)}${script}${html.slice(insertAt)}`;
 };
 
-export const injectPublicAppConfigIntoResponse = async (
+const HEAD_SEARCH_LIMIT = 32_768;
+
+const createPublicAppConfigTransform = (
+  config: PublicAppConfig,
+): TransformStream<Uint8Array, Uint8Array> => {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const marker = `window.${PUBLIC_APP_CONFIG_GLOBAL}=`;
+  let buffer = "";
+  let injected = false;
+
+  const enqueueText = (
+    controller: TransformStreamDefaultController<Uint8Array>,
+    value: string,
+  ) => {
+    if (value.length === 0) {
+      return;
+    }
+    controller.enqueue(encoder.encode(value));
+  };
+
+  const flushBufferedHtml = (
+    controller: TransformStreamDefaultController<Uint8Array>,
+  ) => {
+    if (injected) {
+      enqueueText(controller, buffer);
+      buffer = "";
+      return;
+    }
+    injected = true;
+    enqueueText(controller, injectPublicAppConfig(buffer, config));
+    buffer = "";
+  };
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true });
+      if (injected) {
+        enqueueText(controller, buffer);
+        buffer = "";
+        return;
+      }
+      if (
+        buffer.includes(marker) ||
+        /<head[^>]*>/i.test(buffer) ||
+        buffer.length >= HEAD_SEARCH_LIMIT
+      ) {
+        flushBufferedHtml(controller);
+      }
+    },
+    flush(controller) {
+      buffer += decoder.decode();
+      flushBufferedHtml(controller);
+    },
+  });
+};
+
+export const injectPublicAppConfigIntoResponse = (
   response: Response,
   config: PublicAppConfig = publicAppConfigFromEnv(),
-): Promise<Response> => {
+): Response => {
   const contentType = response.headers.get("content-type") ?? "";
-  if (!contentType.includes("text/html")) {
+  if (!contentType.includes("text/html") || !response.body) {
     return response;
   }
-  const html = await response.text();
-  const injected = injectPublicAppConfig(html, config);
   const headers = new Headers(response.headers);
   headers.delete("content-length");
-  return new Response(injected, {
+  return new Response(response.body.pipeThrough(createPublicAppConfigTransform(config)), {
     status: response.status,
     statusText: response.statusText,
     headers,

--- a/packages/shared/config/public-app-urls.ts
+++ b/packages/shared/config/public-app-urls.ts
@@ -78,20 +78,22 @@ export const resolvePublicAppConfig = (
   buildTime: Partial<PublicAppConfig> = {},
   env: Record<string, string | undefined> = processEnv(),
 ): PublicAppConfig => {
-  const runtime = readRuntimePublicAppConfig();
+  const hasRuntime =
+    typeof window !== "undefined" && window[PUBLIC_APP_CONFIG_GLOBAL] !== undefined;
+  if (hasRuntime) {
+    const runtime = readRuntimePublicAppConfig();
+    return {
+      FRONTEND_URL: normalizePublicUrl(runtime.FRONTEND_URL),
+      ADMIN_URL: normalizePublicUrl(runtime.ADMIN_URL),
+      API_BASE_URL: normalizePublicUrl(runtime.API_BASE_URL),
+    };
+  }
+
   const fromEnv = publicAppConfigFromEnv(env);
   return {
-    FRONTEND_URL: firstPublicUrl(
-      runtime.FRONTEND_URL,
-      fromEnv.FRONTEND_URL,
-      buildTime.FRONTEND_URL,
-    ),
-    ADMIN_URL: firstPublicUrl(runtime.ADMIN_URL, fromEnv.ADMIN_URL, buildTime.ADMIN_URL),
-    API_BASE_URL: firstPublicUrl(
-      runtime.API_BASE_URL,
-      fromEnv.API_BASE_URL,
-      buildTime.API_BASE_URL,
-    ),
+    FRONTEND_URL: firstPublicUrl(fromEnv.FRONTEND_URL, buildTime.FRONTEND_URL),
+    ADMIN_URL: firstPublicUrl(fromEnv.ADMIN_URL, buildTime.ADMIN_URL),
+    API_BASE_URL: firstPublicUrl(fromEnv.API_BASE_URL, buildTime.API_BASE_URL),
   };
 };
 

--- a/packages/shared/config/public-app-urls.ts
+++ b/packages/shared/config/public-app-urls.ts
@@ -1,0 +1,137 @@
+/**
+ * Public origin URLs for the customer app, admin app, and API.
+ *
+ * Vite `VITE_*` values are compiled into the client bundle at build time.
+ * Hostinger, Docker, and similar platforms often set the same keys only at
+ * runtime. The Node servers inject `window.__APP_CONFIG__` from `process.env`
+ * so cross-app links (e.g. admin "Back to App") follow the deployed origins.
+ */
+
+export const PUBLIC_APP_CONFIG_GLOBAL = "__APP_CONFIG__";
+
+export type PublicAppConfig = {
+  FRONTEND_URL: string;
+  ADMIN_URL: string;
+  API_BASE_URL: string;
+};
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: Partial<PublicAppConfig>;
+  }
+}
+
+const processEnv = (): Record<string, string | undefined> => {
+  if (typeof process === "undefined" || typeof process.env === "undefined") {
+    return {};
+  }
+  return process.env;
+};
+
+export const normalizePublicUrl = (value: string | undefined | null): string => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return trimmed.replace(/\/+$/, "");
+};
+
+export const firstPublicUrl = (...values: Array<string | undefined | null>): string => {
+  for (const value of values) {
+    const normalized = normalizePublicUrl(value);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return "";
+};
+
+export const joinPublicUrl = (base: string, path: string): string => {
+  const origin = normalizePublicUrl(base);
+  if (!origin) {
+    return "";
+  }
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `${origin}${suffix}`;
+};
+
+export const publicAppConfigFromEnv = (
+  env: Record<string, string | undefined> = processEnv(),
+): PublicAppConfig => ({
+  FRONTEND_URL: firstPublicUrl(env.VITE_FRONTEND_URL, env.FRONTEND_URL, env.FE_BASE_URL),
+  ADMIN_URL: firstPublicUrl(env.VITE_ADMIN_URL, env.ADMIN_URL),
+  API_BASE_URL: firstPublicUrl(env.VITE_API_BASE_URL, env.API_BASE_URL),
+});
+
+export const readRuntimePublicAppConfig = (): Partial<PublicAppConfig> => {
+  if (typeof window === "undefined") {
+    return {};
+  }
+  const runtime = window[PUBLIC_APP_CONFIG_GLOBAL];
+  if (!runtime || typeof runtime !== "object") {
+    return {};
+  }
+  return runtime;
+};
+
+export const resolvePublicAppConfig = (
+  buildTime: Partial<PublicAppConfig> = {},
+  env: Record<string, string | undefined> = processEnv(),
+): PublicAppConfig => {
+  const runtime = readRuntimePublicAppConfig();
+  const fromEnv = publicAppConfigFromEnv(env);
+  return {
+    FRONTEND_URL: firstPublicUrl(
+      runtime.FRONTEND_URL,
+      fromEnv.FRONTEND_URL,
+      buildTime.FRONTEND_URL,
+    ),
+    ADMIN_URL: firstPublicUrl(runtime.ADMIN_URL, fromEnv.ADMIN_URL, buildTime.ADMIN_URL),
+    API_BASE_URL: firstPublicUrl(
+      runtime.API_BASE_URL,
+      fromEnv.API_BASE_URL,
+      buildTime.API_BASE_URL,
+    ),
+  };
+};
+
+export const serializePublicAppConfigScript = (config: PublicAppConfig): string => {
+  const json = JSON.stringify(config).replace(/</g, "\\u003c");
+  return `<script>window.${PUBLIC_APP_CONFIG_GLOBAL}=${json};</script>`;
+};
+
+export const injectPublicAppConfig = (
+  html: string,
+  config: PublicAppConfig = publicAppConfigFromEnv(),
+): string => {
+  const marker = `window.${PUBLIC_APP_CONFIG_GLOBAL}=`;
+  if (html.includes(marker)) {
+    return html;
+  }
+  const script = serializePublicAppConfigScript(config);
+  const headOpen = html.match(/<head[^>]*>/i);
+  if (!headOpen || headOpen.index === undefined) {
+    return `${script}${html}`;
+  }
+  const insertAt = headOpen.index + headOpen[0].length;
+  return `${html.slice(0, insertAt)}${script}${html.slice(insertAt)}`;
+};
+
+export const injectPublicAppConfigIntoResponse = async (
+  response: Response,
+  config: PublicAppConfig = publicAppConfigFromEnv(),
+): Promise<Response> => {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html")) {
+    return response;
+  }
+  const html = await response.text();
+  const injected = injectPublicAppConfig(html, config);
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(injected, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};

--- a/packages/shared/config/public-app-urls.ts
+++ b/packages/shared/config/public-app-urls.ts
@@ -121,17 +121,19 @@ export const injectPublicAppConfig = (
 
 const HEAD_SEARCH_LIMIT = 32_768;
 
-const createPublicAppConfigTransform = (
+const injectPublicAppConfigIntoStream = (
+  body: ReadableStream<Uint8Array>,
   config: PublicAppConfig,
-): TransformStream<Uint8Array, Uint8Array> => {
+): ReadableStream<Uint8Array> => {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
   const marker = `window.${PUBLIC_APP_CONFIG_GLOBAL}=`;
+  const reader = body.getReader();
   let buffer = "";
   let injected = false;
 
   const enqueueText = (
-    controller: TransformStreamDefaultController<Uint8Array>,
+    controller: ReadableStreamDefaultController<Uint8Array>,
     value: string,
   ) => {
     if (value.length === 0) {
@@ -140,9 +142,7 @@ const createPublicAppConfigTransform = (
     controller.enqueue(encoder.encode(value));
   };
 
-  const flushBufferedHtml = (
-    controller: TransformStreamDefaultController<Uint8Array>,
-  ) => {
+  const flushBufferedHtml = (controller: ReadableStreamDefaultController<Uint8Array>) => {
     if (injected) {
       enqueueText(controller, buffer);
       buffer = "";
@@ -153,25 +153,34 @@ const createPublicAppConfigTransform = (
     buffer = "";
   };
 
-  return new TransformStream<Uint8Array, Uint8Array>({
-    transform(chunk, controller) {
-      buffer += decoder.decode(chunk, { stream: true });
-      if (injected) {
-        enqueueText(controller, buffer);
-        buffer = "";
-        return;
-      }
-      if (
-        buffer.includes(marker) ||
-        /<head[^>]*>/i.test(buffer) ||
-        buffer.length >= HEAD_SEARCH_LIMIT
-      ) {
-        flushBufferedHtml(controller);
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          buffer += decoder.decode();
+          flushBufferedHtml(controller);
+          controller.close();
+          return;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        if (injected) {
+          enqueueText(controller, buffer);
+          buffer = "";
+          return;
+        }
+        if (
+          buffer.includes(marker) ||
+          /<head[^>]*>/i.test(buffer) ||
+          buffer.length >= HEAD_SEARCH_LIMIT
+        ) {
+          flushBufferedHtml(controller);
+          return;
+        }
       }
     },
-    flush(controller) {
-      buffer += decoder.decode();
-      flushBufferedHtml(controller);
+    cancel(reason) {
+      return reader.cancel(reason);
     },
   });
 };
@@ -186,7 +195,7 @@ export const injectPublicAppConfigIntoResponse = (
   }
   const headers = new Headers(response.headers);
   headers.delete("content-length");
-  return new Response(response.body.pipeThrough(createPublicAppConfigTransform(config)), {
+  return new Response(injectPublicAppConfigIntoStream(response.body, config), {
     status: response.status,
     statusText: response.statusText,
     headers,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,9 @@
     "build": "bun build ./index.ts ./interfaces/example.ts ./interfaces/chat.ts --outdir ./dist --splitting --packages external --minify",
     "clean": "rm -rf node_modules dist",
     "lint": "bun run biome lint ./index.ts ./interfaces ./config ./auth",
-    "format": "bun run biome format --write ./index.ts ./interfaces ./config ./auth"
+    "format": "bun run biome format --write ./index.ts ./interfaces ./config ./auth",
+    "test": "bun test --preload ../../apps/frontend/happydom.ts",
+    "test:coverage": "bun test --coverage --preload ../../apps/frontend/happydom.ts"
   },
   "dependencies": {
     "zod": "^4.3.5"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,8 +13,8 @@
     "clean": "rm -rf node_modules dist",
     "lint": "bun run biome lint ./index.ts ./interfaces ./config ./auth",
     "format": "bun run biome format --write ./index.ts ./interfaces ./config ./auth",
-    "test": "bun test --preload ../../apps/frontend/happydom.ts",
-    "test:coverage": "bun test --coverage --preload ../../apps/frontend/happydom.ts"
+    "test": "bun test --preload ../../apps/frontend/happydom.ts config",
+    "test:coverage": "bun test --coverage --preload ../../apps/frontend/happydom.ts config"
   },
   "dependencies": {
     "zod": "^4.3.5"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In deployed environments (Hostinger, Docker, Fly, Cloudflare Pages), admin **Back to App** and frontend **Admin** links could point at the wrong app.

Vite `VITE_FRONTEND_URL` / `VITE_ADMIN_URL` are compiled into the client bundle at **build** time. Platforms that set those keys only as runtime env vars left them empty in the browser. The admin then built a relative URL like `undefined/auth/login` and stayed on the admin app. Frontend fell back to `http://localhost:5175`.

The mock admin demo was still baking `frontend.demo.fullstackbun.dev` because Cloudflare Pages dashboard `VITE_*` values overrode `.env.demo`.

Fly `fly.toml` also shipped placeholder `[env]` URLs (`https://admin.yourdomain.com`). Operators who only customized `[build.args]` / `--build-arg` still got the placeholder at runtime, because the server injects `window.__APP_CONFIG__` from `process.env`.

## Changes

- Production admin/frontend servers inject `window.__APP_CONFIG__` from `process.env` into HTML responses.
- Real runtime origins override build-time values. Empty or unset runtime values fall through to env, then to the Vite-baked origin, so Fly `--build-arg` URLs still apply.
- Frontend/admin `fly.toml` keep `VITE_*` in `[build.args]` only — no placeholder `[env]` URLs.
- Config injection uses a transform stream so React SSR can flush the document shell without buffering the full HTML body.
- Missing frontend origin no longer redirects onto the admin app.
- Frontend no longer uses a localhost admin fallback in production.
- Demo/mock builds (`VITE_ADMIN_DEMO=true`) always apply `apps/admin/.env.demo`, so stale Pages dashboard vars cannot point **Back to App** at the wrong host.
- `docker-compose.prod.yml` now builds and runs the admin service with `VITE_FRONTEND_URL`.

## How to verify

1. Set runtime env on a Node-hosted admin app: `VITE_FRONTEND_URL=https://your-frontend.example.com`
2. Open the admin sidebar and confirm **Back to App** goes to that origin, not the admin host.
3. Unauthenticated admin visits should redirect to `https://your-frontend.example.com/auth/login`.
4. Deploy frontend with only `--build-arg VITE_ADMIN_URL=https://fullstack-bun-admin.fly.dev` and no matching `[env]` value. The Admin link should use that origin, not `https://admin.yourdomain.com`.
5. Cloudflare Pages preview for this branch should link to `https://demo-fullstackbun.estepanov.com`, not `frontend.demo.fullstackbun.dev`.
6. Tests: `bun --filter=shared run test`, `bun --filter=admin run test`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33276157-8831-4e6f-aabb-0e4d79c4b0e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33276157-8831-4e6f-aabb-0e4d79c4b0e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

