### PR TITLE
chore(env): add Cloud Agent development environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,8 +5,8 @@
   "terminals": [
     {
       "name": "dev",
-      "command": "export PATH=\"$HOME/.bun/bin:$PATH\" && bun run dev",
-      "description": "Runs the frontend (5173), admin (5175), and API (3001) dev servers concurrently."
+      "command": "export PATH=\"$HOME/.bun/bin:$PATH\" && bash .cursor/start.sh && bun run dev",
+      "description": "Ensures PostgreSQL + Redis are up (idempotent), then runs the frontend (5173), admin (5175), and API (3001) dev servers concurrently."
     }
   ],
   "ports": [

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,17 @@
+{
+  "name": "Fullstack Bun",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "export PATH=\"$HOME/.bun/bin:$PATH\" && bun run dev",
+      "description": "Runs the frontend (5173), admin (5175), and API (3001) dev servers concurrently."
+    }
+  ],
+  "ports": [
+    { "name": "api", "port": 3001 },
+    { "name": "frontend", "port": 5173 },
+    { "name": "admin", "port": 5175 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent install script for the Fullstack Bun monorepo.
+# Prepares the base image + repository dependencies so the app can run:
+#   - Bun runtime
+#   - PostgreSQL + Redis (system packages)
+#   - Workspace JS dependencies
+#   - .env files for api / frontend / admin
+#   - Database role, database, and Drizzle migrations
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export PATH="$HOME/.bun/bin:$PATH"
+
+echo "==> Ensuring Bun is installed"
+if ! command -v bun >/dev/null 2>&1; then
+  curl -fsSL https://bun.sh/install | bash
+  export PATH="$HOME/.bun/bin:$PATH"
+fi
+bun --version
+
+echo "==> Ensuring PostgreSQL and Redis are installed"
+if ! command -v pg_ctlcluster >/dev/null 2>&1 || ! command -v redis-server >/dev/null 2>&1; then
+  sudo apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    postgresql postgresql-contrib redis-server
+fi
+
+echo "==> Starting PostgreSQL and Redis (needed for migrations)"
+sudo service postgresql start
+sudo service redis-server start
+
+echo "==> Waiting for PostgreSQL to accept connections"
+for _ in $(seq 1 30); do
+  if pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "==> Configuring PostgreSQL role and database"
+sudo -u postgres psql -v ON_ERROR_STOP=1 -c "ALTER USER postgres WITH PASSWORD 'postgres';"
+if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='mydatabase'" | grep -q 1; then
+  sudo -u postgres createdb mydatabase
+fi
+
+echo "==> Installing workspace dependencies"
+bun install
+
+echo "==> Generating .env files (only if missing)"
+if [ ! -f apps/api/.env ]; then
+  cp apps/api/.env.example apps/api/.env
+  # Local Redis has no password; point at localhost.
+  sed -i 's#^REDIS_URL=.*#REDIS_URL="redis://localhost:6379"#' apps/api/.env
+  # Better Auth requires a >= 32 char secret.
+  SECRET="$(openssl rand -base64 32)"
+  sed -i "s#^BETTER_AUTH_SECRET=.*#BETTER_AUTH_SECRET=\"${SECRET}\"#" apps/api/.env
+fi
+[ -f apps/frontend/.env ] || cp apps/frontend/.env.example apps/frontend/.env
+[ -f apps/admin/.env ] || cp apps/admin/.env.example apps/admin/.env
+
+echo "==> Applying database migrations"
+(cd apps/api && bun run db:migrate)
+
+echo "==> Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Per-boot start script for the Fullstack Bun monorepo.
+# Brings up the infrastructure the API depends on (PostgreSQL + Redis) and
+# reconciles database migrations. Dependencies and data persist from the
+# install/snapshot phase; this only restarts ephemeral processes.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+export PATH="$HOME/.bun/bin:$PATH"
+
+echo "==> Starting PostgreSQL and Redis"
+sudo service postgresql start
+sudo service redis-server start
+
+echo "==> Waiting for PostgreSQL to accept connections"
+for _ in $(seq 1 30); do
+  if pg_isready -h 127.0.0.1 -p 5432 >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "==> Verifying Redis"
+redis-cli ping || true
+
+# Apply any migrations added on the current branch. Safe/idempotent: Drizzle
+# only applies pending migrations. Never blocks boot on failure.
+if [ -f apps/api/.env ]; then
+  echo "==> Applying database migrations"
+  (cd apps/api && bun run db:migrate) || echo "WARN: migrations skipped/failed"
+fi
+
+echo "==> Start complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repo-managed Cloud Agent environment so this monorepo becomes fully runnable in a fresh VM with no manual steps. Previously there was no `.cursor/environment.json`, so Cloud Agents booted with nothing provisioned (no Bun, no PostgreSQL, no Redis).

## What's included

- `.cursor/environment.json` — repo-managed environment config. Declares the `install`/`start` lifecycle scripts, a self-provisioning `dev` terminal that runs all three apps, and exposes ports 3001 (API), 5173 (frontend), 5175 (admin).
- `.cursor/install.sh` — idempotent install phase: installs Bun, PostgreSQL, and Redis; runs `bun install`; generates `.env` files for `api`/`frontend`/`admin` (with a valid `BETTER_AUTH_SECRET` and a local passwordless `REDIS_URL`); creates the `postgres` role/`mydatabase` database; applies Drizzle migrations.
- `.cursor/start.sh` — per-boot phase: starts PostgreSQL + Redis, waits for readiness, and reconciles pending migrations.

## Why this shape

- System dependencies + one-time repo setup live in `install` (runs once to build the snapshot).
- Ephemeral services (PostgreSQL, Redis) are (re)started in `start` on every boot, since processes don't survive a snapshot.
- The `dev` terminal runs `start.sh` (idempotent) and then `bun run dev`, so infra is guaranteed up before the servers start — the app works regardless of boot-time `start`-phase timing.

## Verification

Validated end-to-end on a fresh VM and in a fresh prebuilt environment build:

- `install.sh` runs to completion and is idempotent (ran twice cleanly).
- `start.sh` starts services and applies migrations.
- API `/health` returns `{"status":"ok","services":{"database":"ok","redis":"ok"}}`.
- Frontend (5173) and admin (5175) both serve HTTP 200.
- Full app flow works: signed up + signed in a user (persisted to PostgreSQL) and sent a real-time chat message over WebSocket.
- A **draft environment build succeeded** provisioning everything from scratch on the default image (Bun + PostgreSQL + Redis + deps + migrations).
- A **fresh Cloud Agent booted from that build** passed 6/6 checks (tool versions, migrated schema, `.env` present, `/health` = ok, frontend + admin = 200).

[fullstack_bun_signin_and_chat_demo.mp4](https://cursor.com/agents/bc-8fb6464b-75a0-4e24-a3f0-8e58b4416587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffullstack_bun_signin_and_chat_demo.mp4)

[Authenticated Chat Demo with a sent message](https://cursor.com/agents/bc-8fb6464b-75a0-4e24-a3f0-8e58b4416587/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_authenticated_chat.webp)

## Notes

- `.env` files are generated by `install.sh` and remain gitignored; no secrets are committed.
- Email verification requires SMTP, which isn't configured in dev, so email-verified flows need SMTP env vars (or manual verification) to fully exercise.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fb6464b-75a0-4e24-a3f0-8e58b4416587?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fb6464b-75a0-4e24-a3f0-8e58b4416587&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

